### PR TITLE
Add system packages from ansible migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,27 @@
+# NixOS Workstation - Project Guide
+
+## Goal
+This repo is a **temporary standalone** NixOS config for the ThinkPad, migrated from the Ansible-based setup at ~/git/cwage/thinkpad. The primary goal is to eventually fold this into the **homelab monorepo** (https://github.com/cwage/homelab) per https://github.com/cwage/homelab/issues/133, where it will coexist alongside Proxmox VM configs, with hosts like `thinkpad/` and `workstation/` using Home Manager for user-level config.
+
+Everything done here should be structured with that integration in mind — keep configs modular, avoid hard-coding thinkpad-specific assumptions where possible, and follow the target structure outlined in the homelab issue.
+
+## Build & Deploy
+```bash
+sudo nixos-rebuild switch --flake .#thinkpad
+```
+
+## Architecture
+- `flake.nix` — Entry point, defines inputs (nixpkgs, home-manager, dotfiles)
+- `hosts/thinkpad/` — Host-specific config (configuration.nix, hardware-configuration.nix)
+- Dotfiles managed via a separate flake at ~/git/cwage/dotfiles, imported as a Home Manager module
+
+## Migration Notes (from ansible)
+- **No music production.** The old ansible config had JACK/ardour/fluidsynth for audio production — this is no longer a goal. Standard desktop audio (pipewire + pulse + alsa) is sufficient.
+- **Build dependencies (libssl-dev, etc.) belong in per-project devShells**, not in global system packages.
+- **Pinned binaries** (Bitwarden CLI, VS Launcher, r2modman, Codex, Proton Mail Bridge) are handled separately from standard system packages.
+- **ufw is unnecessary** — NixOS has networking.firewall built-in.
+
+## Conventions
+- Keep changes scoped and modular; avoid monolithic configs.
+- The user prefers to handle git commits and PRs. Don't commit or push without being asked.
+- When suggesting system commands (rebuilds, deploys), prefer telling the user the command rather than running it automatically.

--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -56,10 +56,12 @@
   services.displayManager.defaultSession = "none+xsession";
 
   # Enable sound with pipewire
+  security.rtkit.enable = true;
   services.pipewire = {
     enable = true;
     pulse.enable = true;
     alsa.enable = true;
+    alsa.support32Bit = true;
   };
 
   # Enable touchpad support
@@ -67,6 +69,9 @@
 
   # Power management (battery info for xfce4-power-manager)
   services.upower.enable = true;
+
+  # UDisks2 (required for udiskie automount/tray)
+  services.udisks2.enable = true;
 
   # Define a user account. Don't forget to set a password with 'passwd'.
   users.users.cwage = {
@@ -76,6 +81,9 @@
       tree
     ];
   };
+
+  # Enable flakes and the new nix CLI
+  nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
   # Allow non-free
   nixpkgs.config.allowUnfree = true;
@@ -93,11 +101,11 @@
     ripgrep
 
     # X11 / Xorg tools
-    xorg.xkbcomp
-    xorg.xrdb
-    xorg.xsetroot
-    xorg.setxkbmap
-    xorg.xauth
+    xkbcomp
+    xrdb
+    xsetroot
+    setxkbmap
+    xauth
 
     # Window manager and session
     awesome
@@ -111,25 +119,58 @@
     # Desktop utilities
     dunst                          # notifications
     networkmanagerapplet           # nm-applet
-    xfce.xfce4-power-manager
-    xfce.xfconf                    # settings daemon for xfce4-power-manager
-    volumeicon
+    xfce4-power-manager
+    xfconf                         # settings daemon for xfce4-power-manager
+    volumeicon                     # systray volume icon
+    pavucontrol                    # PulseAudio volume control GUI
+    brightnessctl                  # backlight control
     polkit_gnome                   # policykit auth agent
     udiskie                        # automount
     arandr                         # xrandr GUI
     scrot                          # screenshots
     xclip                          # clipboard
-    volumeicon                     # systray volume icon
+
+    # Browser
+    brave
 
     # Apps
     emacs
     signal-desktop
+    slack
 
-    # Your other tools
+    # Media
+    ffmpeg
+    mpv
+    mplayer
+    pulsemixer
+    mpd
+    mpc
+
+    # Image tools
+    gthumb
+    imagemagick
+
+    # Network / system tools
+    nmap
+    socat
+    wireguard-tools
+    plocate
+
+    # Gaming
+    dotnet-runtime_8
+
+    # Utilities
     btop
     w3m
     mutt
     gh
+    pass
+    swaks
+    ddgr
+    yt-dlp
+    exfatprogs
+    grip
+    pinentry-gnome3
   ];
 
   # Enable gnome-keyring for secrets (optional, used by some apps)
@@ -146,14 +187,24 @@
     enableSSHSupport = false;  # You use ssh-agent in .xsession
   };
 
-  # Enable the OpenSSH daemon.
-  # services.openssh.enable = true;
+  # OpenSSH daemon
+  services.openssh.enable = true;
 
-  # Open ports in the firewall.
-  # networking.firewall.allowedTCPPorts = [ ... ];
-  # networking.firewall.allowedUDPPorts = [ ... ];
-  # Or disable the firewall altogether.
-  # networking.firewall.enable = false;
+  # Flatpak (for apps like ncspot, Zoom)
+  services.flatpak.enable = true;
+  xdg.portal.enable = true;
+  xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
+  xdg.portal.config.common.default = "*";
+
+  # Steam
+  programs.steam.enable = true;
+
+  # Firewall (NixOS iptables-based, replaces ufw)
+  networking.firewall = {
+    enable = true;
+    allowedTCPPorts = [ 22 ];      # SSH
+    # allowedUDPPorts = [ ];
+  };
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions


### PR DESCRIPTION
## Summary
- Migrate remaining standard system packages from the ansible-based thinkpad setup (~/git/cwage/thinkpad)
- Enable NixOS services: openssh, flatpak (+ XDG portals), steam, udisks2, firewall (TCP 22)
- Enable `nix-command` and `flakes` experimental features globally
- Add pipewire `rtkit` and 32-bit ALSA support
- Fix deprecated `xorg.*` and `xfce.*` package names
- Add CLAUDE.md with project context and migration notes
- Add `mpd`/`mpc` as xmms2 replacement (config/scripts deferred)

## New packages
**Browser:** brave
**Apps:** slack
**Desktop:** pavucontrol, brightnessctl
**Media:** ffmpeg, mpv, mplayer, pulsemixer, mpd, mpc
**Image:** gthumb, imagemagick
**Network:** nmap, socat, wireguard-tools, plocate
**Gaming:** dotnet-runtime_8 (+ steam via programs.steam)
**Utilities:** pass, swaks, ddgr, yt-dlp, exfatprogs, grip, pinentry-gnome3

## Deferred
- Docker and NFS/autofs support → #3
- Pinned binaries (Bitwarden CLI, VS Launcher, r2modman, Codex, Proton Mail Bridge)
- Audio production packages (ardour, fluidsynth, JACK) — no longer needed
- pktstat — not in nixpkgs

## Test plan
- [x] `nixos-rebuild dry-build` passes with no errors or warnings
- [x] `nixos-rebuild switch` applied successfully
- [x] udiskie tray icon works (required udisks2 service)

🤖 Generated with [Claude Code](https://claude.com/claude-code)