### PR TITLE
Add autofs/NFS for NAS shares over WireGuard

### DIFF
--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -157,6 +157,7 @@
     nmap
     socat
     wireguard-tools
+    nfs-utils
     plocate
 
     # Gaming
@@ -212,6 +213,11 @@
       ${pkgs.systemd}/bin/resolvectl domain wg0 lan.quietlife.net
     '';
     postDown = ''
+      # Lazy-unmount any NFS shares under /mnt/nas before tunnel goes away
+      for mnt in $(${pkgs.gawk}/bin/awk -v base="/mnt/nas/" '$2 ~ "^"base {print $2}' /proc/mounts); do
+        ${pkgs.util-linux}/bin/logger -t nas-wg-unmount "WireGuard down: lazy-unmounting $mnt"
+        ${pkgs.util-linux}/bin/umount -l "$mnt" 2>/dev/null
+      done
       ${pkgs.systemd}/bin/resolvectl revert wg0
     '';
 
@@ -222,6 +228,20 @@
       persistentKeepalive = 25;
     }];
   };
+
+  # NFS client + autofs (NAS shares over WireGuard tunnel)
+  services.autofs = {
+    enable = true;
+    autoMaster = ''
+      /mnt/nas /etc/auto.nas --timeout=300
+    '';
+  };
+
+  environment.etc."auto.nas".text = ''
+    # Wildcard map: /mnt/nas/<share> → 10.10.15.4:/volume1/<share>
+    # Soft mount with aggressive timeouts for roaming laptop use
+    * -fstype=nfs,soft,timeo=30,retrans=2,actimeo=3 10.10.15.4:/volume1/&
+  '';
 
   # Firewall (NixOS iptables-based, replaces ufw)
   networking.firewall = {


### PR DESCRIPTION
## Summary
- Wildcard autofs map auto-mounts Synology NFS exports at `/mnt/nas/<share>` (server `10.10.15.4:/volume1/`)
- Soft NFS mount options (`soft,timeo=30,retrans=2,actimeo=3`) with 300s autofs idle timeout for roaming laptop use
- WireGuard `postDown` hook lazy-unmounts NFS shares before tunnel teardown to prevent stale handles
- Adds `nfs-utils` to system packages

## Test plan
- [x] `nixos-rebuild switch` succeeds
- [x] Accessing `/mnt/nas/<share>` auto-mounts the corresponding NFS export over WireGuard
- [x] Idle shares unmount after timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)