### PR TITLE
Enable rootless Docker with Compose v2

### DIFF
--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -79,7 +79,7 @@
   # Define a user account. Don't forget to set a password with 'passwd'.
   users.users.cwage = {
     isNormalUser = true;
-    extraGroups = [ "wheel" "audio" "video" "networkmanager" "docker" ];
+    extraGroups = [ "wheel" "audio" "video" "networkmanager" ];
     packages = with pkgs; [
       tree
     ];
@@ -200,8 +200,11 @@
   xdg.portal.extraPortals = [ pkgs.xdg-desktop-portal-gtk ];
   xdg.portal.config.common.default = "*";
 
-  # Docker (includes Compose v2 plugin, containerd, buildx)
-  virtualisation.docker.enable = true;
+  # Docker — rootless mode (daemon runs as user, no root-equivalent group)
+  virtualisation.docker.rootless = {
+    enable = true;
+    setSocketVariable = true;
+  };
 
   # Steam
   programs.steam.enable = true;


### PR DESCRIPTION
## Summary
- Enable rootless Docker via `virtualisation.docker.rootless` — daemon runs as a systemd user service, no root-equivalent `docker` group needed
- Includes Compose v2 plugin, containerd, and buildx
- `setSocketVariable = true` sets `DOCKER_HOST` to the per-user socket automatically

## Test plan
- [x] `docker compose version` returns v2
- [x] `docker run --rm alpine echo "hello world"` works without sudo or docker group
- [x] Daemon runs as user service (`systemctl --user status docker`)

Closes #3 (Docker portion; NFS/autofs was completed in #7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)