### PR TITLE
silence the system bell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,3 +46,29 @@ There is no way to update a single package independently — all packages come f
 - Keep changes scoped and modular; avoid monolithic configs.
 - The user prefers to handle git commits and PRs. Don't commit or push without being asked.
 - When suggesting system commands (rebuilds, deploys), prefer telling the user the command rather than running it automatically.
+
+## Debugging defaults / unwanted behavior
+
+When diagnosing unwanted default behavior in NixOS or any well-established
+ecosystem (systemd, pipewire, X11, etc.), there are two phases — and they have
+different right-tools:
+
+1. **Identify the responsible component.** First-principles investigation
+   (mute layers one at a time, capture events with `pactl subscribe` / `pw-mon`
+   / `journalctl -f`, find the actual process/module emitting the behavior) is
+   the right approach here. Don't shortcut this; the wrong component leads to
+   wrong fixes.
+
+2. **Look up the known knob — DO NOT reverse-engineer config syntax.** Once
+   a specific component is named (e.g. `libpipewire-module-x11-bell`), STOP
+   guessing. Search `"how to disable X in nixos"`, check the NixOS Wiki, the
+   upstream project's docs, NixOS Discourse. Most common annoyances have
+   documented one-line fixes. Guessing at config syntax based on partial recall
+   (e.g. trying `flags = [ disabled ]`, env-var workarounds, custom drop-ins)
+   wastes a lot of time and risks brittle hacks when a clean documented option
+   already exists.
+
+Pattern to avoid: spending an hour layering speculative fixes on top of each
+other when 30 seconds of web search would have surfaced the canonical answer.
+Rebuilding packages, patching modules, or shipping custom systemd overrides
+should be **fallbacks** when no documented option exists, never first moves.

--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -28,6 +28,9 @@ in
   boot.loader.efi.canTouchEfiVariables = true;
   boot.loader.grub.useOSProber = true;
 
+  # Disable the PC speaker beep (the "blip" on backspace-at-start-of-line, etc.)
+  boot.blacklistedKernelModules = [ "pcspkr" "snd_pcsp" ];
+
   # Hostname is set in hosts/thinkpad/default.nix
 
   # Configure network connections interactively with nmcli or nmtui.
@@ -68,6 +71,19 @@ in
     pulse.enable = true;
     alsa.enable = true;
     alsa.support32Bit = true;
+
+    # Disable the X11 bell module. PipeWire's upstream pipewire.conf loads
+    # libpipewire-module-x11-bell with `condition = [ { module.x11.bell = !false } ]`,
+    # so setting this context property to false makes the conditional skip the load.
+    # Without this, every X11 BellNotify event (e.g. readline bell-on-error over SSH)
+    # gets caught by the module and played as freedesktop bell.oga via libcanberra
+    # through the default audio sink — independent of `xset b`, pcspkr blacklisting,
+    # xterm bell settings, or anything else you'd normally tweak.
+    extraConfig.pipewire."92-no-x11-bell" = {
+      "context.properties" = {
+        "module.x11.bell" = false;
+      };
+    };
   };
 
   # SDR hardware support (udev rules, plugdev group, kernel module blacklists)

--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -28,7 +28,7 @@ in
   boot.loader.efi.canTouchEfiVariables = true;
   boot.loader.grub.useOSProber = true;
 
-  # Disable the PC speaker beep (the "blip" on backspace-at-start-of-line, etc.)
+  # Disable the legacy PC speaker / TTY beep.
   boot.blacklistedKernelModules = [ "pcspkr" "snd_pcsp" ];
 
   # Hostname is set in hosts/thinkpad/default.nix


### PR DESCRIPTION
## Summary

Two-layer fix to make the system stop emitting bell sounds (most audibly: backspace-at-start-of-line over SSH to non-NixOS hosts that lack the local \`set bell-style none\` /etc/inputrc tweak).

- **\`boot.blacklistedKernelModules = [ "pcspkr" "snd_pcsp" ]\`** — silences the legacy PC speaker beep at the kernel level. Wasn't actually the culprit for the SSH-bell symptom but is reasonable hygiene on a desktop and silences TTY-mode beeps.

- **\`services.pipewire.extraConfig.pipewire."92-no-x11-bell" = { "context.properties" = { "module.x11.bell" = false; }; }\`** — the actual fix. PipeWire's upstream \`pipewire.conf\` loads \`libpipewire-module-x11-bell\` with \`condition = [ { module.x11.bell = !false } ]\`, so flipping that context property makes the conditional load skip the module. Without this, every X11 BellNotify event gets caught and played as freedesktop bell.oga via libcanberra through the default audio sink — independent of \`xset b\`, pcspkr blacklisting, xterm bell settings, or anything else you'd normally tweak.

Also adds a new "Debugging defaults / unwanted behavior" section to CLAUDE.md codifying the lesson from the rabbithole this came out of: first-principles debugging is the right way to *identify* a misbehaving component, but once it's named, look up the documented knob instead of guessing at config syntax.

## Test plan

- [x] \`pw-cli ls Module | grep -i bell\` → empty after rebuild + \`systemctl --user restart pipewire\`
- [x] \`printf '\a'\` locally → silent
- [x] \`ssh felix\` then backspace at start of line → silent
- [x] No regression in normal audio playback (pipewire still serving sinks/sources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)