### PR TITLE
Add sandboxing tools for LLM agent isolation experiments

### DIFF
--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -195,6 +195,16 @@ in
     plocate
     passt                            # pasta networking for rootless Docker
 
+    # Sandboxing / isolation
+    # Experimenting with confining LLM coding agents (Claude Code, codex,
+    # opencode) against prompt-injection threats when working in untrusted repos.
+    bubblewrap                       # unprivileged namespace sandbox
+    firejail                         # profile-based sandbox wrapper
+    nsjail                           # namespaces + seccomp + cgroups in one tool
+    podman-compose                   # rootless container compose (podman enabled below)
+    mitmproxy                        # HTTPS proxy for allowlisting outbound API traffic
+    strace                           # syscall tracer (useful for building seccomp profiles)
+
     # SDR
     hackrf
     rtl-sdr
@@ -269,6 +279,13 @@ in
   systemd.user.services.docker = {
     environment.DOCKERD_ROOTLESS_ROOTLESSKIT_NET = "pasta";
     path = [ pkgs.passt ];
+  };
+
+  # Podman — alternative rootless container runtime, for sandboxing experiments.
+  # dockerCompat is off because rootless docker above already owns that alias.
+  virtualisation.podman = {
+    enable = true;
+    dockerCompat = false;
   };
 
   # Steam


### PR DESCRIPTION
Adds a broad toolkit of Linux sandboxing primitives so we can start experimenting with confining LLM coding agents (Claude Code, codex, opencode) against prompt-injection threats when running against untrusted third-party repos.

## What this adds

System packages:

- `bubblewrap` — unprivileged namespace sandbox; the foundational primitive (Flatpak uses it under the hood)
- `firejail` — profile-based sandbox wrapper; friendlier on-ramp than raw bwrap
- `nsjail` — namespaces + seccomp-bpf + cgroups combined into one tool
- `podman-compose` — rootless container compose, for heavier container-based isolation
- `mitmproxy` — transparent HTTPS proxy for allowlisting outbound API traffic (the hardest part of sandboxing an LLM agent is that it needs API access but nothing else)
- `strace` — syscall tracer, useful when building seccomp profiles

NixOS options:

- `virtualisation.podman.enable = true` with `dockerCompat = false` — rootless podman alongside the existing rootless docker. The alias is off so `docker` still points at the docker daemon we already have set up.

## Deliberately deferred

- **AppArmor** (`security.apparmor.enable` + `apparmor-utils`) — enabling without profiles is mostly harmless, but better to add when we're ready to actually write profiles.
- **gVisor / Kata Containers / microVMs** — heavier isolation, worth revisiting if the lightweight tools prove insufficient.
- **Landlock CLI wrappers** — kernel Landlock support (5.13+) is already available; no package strictly needed to start experimenting.

## Test Plan

- [ ] `nix flake check --no-build` passes (verified locally)
- [ ] `sudo nixos-rebuild switch --flake .#thinkpad` succeeds
- [ ] Spot-check: `bwrap --version`, `firejail --version`, `nsjail --help`, `podman --version`, `podman-compose --version`, `mitmproxy --version`, `strace --version`
- [ ] `systemctl --user status docker` still healthy (no conflict with podman)
