### PR TITLE
wrap claude and codex with agentpen by default

### DIFF
--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -13,6 +13,25 @@ let
     systemImageTypes = [ "google_apis" ];
     abiVersions = [ "x86_64" ];
   }).androidsdk;
+
+  agentpen = pkgs.callPackage ../../pkgs/agentpen.nix { };
+
+  # Shadow `claude` / `codex` in PATH with agentpen wrappers. The wrappers
+  # reference the real binaries by absolute store path so agentpen's own
+  # PATH lookup can't recurse into the wrapper. Sibling `*-raw` shims expose
+  # the unwrapped binaries for when sandboxing isn't wanted.
+  wrapAgent = name: realPath: pkgs.writeShellScriptBin name ''
+    exec ${agentpen}/bin/agentpen --agent ${name} ${realPath} "$@"
+  '';
+  rawAgent = name: realPath: pkgs.writeShellScriptBin "${name}-raw" ''
+    exec ${realPath} "$@"
+  '';
+  agentWrappers = [
+    (wrapAgent "claude" "${pkgs.claude-code}/bin/claude")
+    (rawAgent  "claude" "${pkgs.claude-code}/bin/claude")
+    (wrapAgent "codex"  "${pkgs.codex}/bin/codex")
+    (rawAgent  "codex"  "${pkgs.codex}/bin/codex")
+  ];
 in
 {
   imports =
@@ -129,8 +148,7 @@ in
     vim
     tmux
     mosh
-    claude-code
-    codex
+    agentpen
     opencode
     git
     curl
@@ -239,7 +257,7 @@ in
     exfatprogs
     python3Packages.grip
     pinentry-gnome3
-  ];
+  ] ++ agentWrappers;
 
   # Android: ANDROID_SDK_ROOT for emulator/gradle (adb udev handled by systemd 258)
   environment.variables.ANDROID_SDK_ROOT = "${androidSdk}/libexec/android-sdk";

--- a/pkgs/agentpen.nix
+++ b/pkgs/agentpen.nix
@@ -1,0 +1,32 @@
+{ lib, buildGoModule, fetchFromGitHub }:
+
+buildGoModule rec {
+  pname = "agentpen";
+  version = "0.2.1";
+
+  src = fetchFromGitHub {
+    owner = "cwage";
+    repo = "agentpen";
+    rev = "v${version}";
+    hash = "sha256-JHitzosD6lsAoUq2gPwgEA2PqcOvB9s3z2ljFogR2vc=";
+  };
+
+  vendorHash = "sha256-LXR8/S1x5FOxgcp8uXppc2foxwHZq6KANA3WCtX0MoE=";
+
+  ldflags = [
+    "-s" "-w"
+    "-X main.version=${version}"
+  ];
+
+  # TestStageEtc_HostsAndResolvConf reads /etc/resolv.conf on the host, which
+  # isn't visible inside the nix build sandbox.
+  checkFlags = [ "-skip=^TestStageEtc_HostsAndResolvConf$" ];
+
+  meta = {
+    description = "Confinement wrapper for LLM coding agents";
+    homepage = "https://github.com/cwage/agentpen";
+    license = lib.licenses.mit;
+    mainProgram = "agentpen";
+    platforms = [ "x86_64-linux" ];
+  };
+}


### PR DESCRIPTION
Wrap `claude` and `codex` with [agentpen](https://github.com/cwage/agentpen) by default so they run inside the `untrusted` profile sandbox (pasta + bwrap + nft + seccomp + SNI-gated egress) when invoked from PATH. Sibling `claude-raw` / `codex-raw` shims expose the unwrapped binaries for cases where sandboxing isn't wanted.

## Changes
- `pkgs/agentpen.nix`: new `buildGoModule` derivation pinned to `v0.2.1`. Skips `TestStageEtc_HostsAndResolvConf` (reads host `/etc/resolv.conf`, not visible in the nix build sandbox).
- `hosts/thinkpad/configuration.nix`: adds `wrapAgent`/`rawAgent` helpers and an `agentWrappers` list. Drops `claude-code` and `codex` from `environment.systemPackages` to avoid `bin/claude` / `bin/codex` profile collisions; the underlying packages are still realized into the store as build-time deps of the wrappers (the wrappers `exec ${pkgs.claude-code}/bin/claude` etc. by absolute store path so agentpen's own PATH lookup can't recurse into the wrapper).

## Test Plan
- [x] `sudo nixos-rebuild switch --flake .#thinkpad` succeeds
- [x] `which claude` → `/run/current-system/sw/bin/claude`; `cat $(which claude)` shows the agentpen invocation pointing at the real `claude-code` store path
- [ ] `claude-raw` / `codex-raw` resolve to the unwrapped binaries
- [ ] `agentpen --check` reports the host's enforceable sandbox layers

## Future bumps
Edit `version` in `pkgs/agentpen.nix`, refresh `hash` (via `nix-prefetch-url --unpack https://github.com/cwage/agentpen/archive/refs/tags/v<NEW>.tar.gz`) and `vendorHash` (set to `lib.fakeHash` and copy from the build error), then rebuild.
