### PR TITLE
docs: fix rollback command for flake-based config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,37 @@ sudo nixos-rebuild switch --flake .#thinkpad
 
 Nothing changes on your running system until you rebuild. If something breaks after a rebuild:
 ```bash
-sudo nixos-rebuild switch --rollback
+sudo nixos-rebuild switch --rollback --flake .#thinkpad
 ```
+
+The `--flake .#thinkpad` is **required** even for rollback. Without it,
+`nixos-rebuild` falls through to the legacy `<nixpkgs/nixos>` NIX_PATH lookup
+(which this flake-based setup doesn't have configured) and errors out *before*
+it ever reaches the rollback logic. The rollback itself doesn't rebuild
+anything — it just re-activates a previous system closure that's already in
+the Nix store — but the tool still wants to evaluate the flake to figure out
+which version of `nixos-rebuild` to re-exec as.
+
+### Emergency rollback (when `nixos-rebuild` itself won't evaluate)
+
+If even the command above fails (e.g. the flake doesn't evaluate at all, or
+something in the toolchain is broken), bypass `nixos-rebuild` and switch the
+system profile directly. The previous generation's closure is in the store,
+so this is fast and offline:
+
+```bash
+# 1. List generations to pick the prior one
+sudo nix-env --list-generations -p /nix/var/nix/profiles/system | tail -5
+
+# 2. Switch the profile pointer to that generation number
+sudo nix-env --switch-generation <N> -p /nix/var/nix/profiles/system
+
+# 3. Activate it
+sudo /nix/var/nix/profiles/system/bin/switch-to-configuration switch
+```
+
+Same effect as `--rollback`, but with zero evaluation needed. Final fallback
+beyond this: reboot and select a previous generation from the GRUB menu.
 
 There is no way to update a single package independently — all packages come from the same pinned nixpkgs commit. If you need to pin a specific version of one package ahead of nixpkgs, use an overlay in `flake.nix` to override that package's version and hash.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,7 +37,7 @@ sudo nixos-rebuild switch --flake .#thinkpad
 
 Nothing changes on your running system until you rebuild. If something breaks after a rebuild:
 ```bash
-sudo nixos-rebuild switch --rollback --flake .#thinkpad
+sudo nixos-rebuild switch --flake .#thinkpad --rollback
 ```
 
 The `--flake .#thinkpad` is **required** even for rollback. Without it,


### PR DESCRIPTION
`sudo nixos-rebuild switch --rollback` (as previously documented) fails on this flake-based setup. `nixos-rebuild` evaluates the system config to figure out which version of itself to re-exec as *before* it reaches rollback logic — and without `--flake`, it falls through to a legacy `<nixpkgs/nixos>` NIX_PATH lookup that isn't configured here, so it errors before doing anything. Hit this today during awesome breakage triage.

## Changes

- `CLAUDE.md` — update the documented rollback command to `sudo nixos-rebuild switch --flake .#thinkpad --rollback` and explain why the flag is needed even when no rebuild happens.
- Add an "Emergency rollback" section documenting direct `/nix/var/nix/profiles/system` switching via `nix-env --switch-generation` + `switch-to-configuration switch`, for cases where `nixos-rebuild` itself can't evaluate (broken flake, broken toolchain, etc.). This is the route used to recover today.

## Test Plan

- [x] Reviewed both code paths during the awesome breakage incident — direct-profile route works without any evaluation; `--rollback --flake` is the right invocation per the nixos-rebuild source.
- [ ] Verify on next rebuild that `--rollback --flake .#thinkpad` is the working invocation (not blocking — purely doc-level change).
