### PR TITLE
pin awesome to known-good nixpkgs; advance nixpkgs

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -57,11 +57,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777954456,
-        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "lastModified": 1779508470,
+        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "rev": "29916453413845e54a65b8a1cf996842300cd299",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -71,12 +71,29 @@
         "type": "github"
       }
     },
+    "nixpkgs-awesome": {
+      "locked": {
+        "lastModified": 1777954456,
+        "narHash": "sha256-hGdgeU2Nk87RAuZyYjyDjFL6LK7dAZN5RE9+hrDTkDU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "549bd84d6279f9852cae6225e372cc67fb91a4c1",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "dotfiles": "dotfiles",
         "home-manager": "home-manager",
         "nix-index-database": "nix-index-database",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-awesome": "nixpkgs-awesome"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,13 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
+    # Pinned to a pre-2026-05-08 nixos-unstable commit for awesome 4.3, which
+    # broke against the lgi/cairo bump that landed via staging-next on
+    # 2026-05-08. Both build and runtime fail in lgi/override/cairo.lua.
+    # Tracked upstream in NixOS/nixpkgs#523345 — when that's fixed, drop this
+    # input and the overlay below.
+    nixpkgs-awesome.url = "github:NixOS/nixpkgs/549bd84d6279f9852cae6225e372cc67fb91a4c1";
+
     home-manager = {
       url = "github:nix-community/home-manager";
       inputs.nixpkgs.follows = "nixpkgs";
@@ -20,10 +27,13 @@
     };
   };
 
-  outputs = { self, nixpkgs, home-manager, dotfiles, nix-index-database, ... }:
+  outputs = { self, nixpkgs, nixpkgs-awesome, home-manager, dotfiles, nix-index-database, ... }:
   let
     system = "x86_64-linux";
     pkgs = nixpkgs.legacyPackages.${system};
+    awesomeOverlay = (final: prev: {
+      awesome = nixpkgs-awesome.legacyPackages.${system}.awesome;
+    });
   in
   {
     packages.${system} = {
@@ -33,6 +43,7 @@
     nixosConfigurations.thinkpad = nixpkgs.lib.nixosSystem {
       inherit system;
       modules = [
+        { nixpkgs.overlays = [ awesomeOverlay ]; }
         ./hosts/thinkpad
         nix-index-database.nixosModules.nix-index
         home-manager.nixosModules.home-manager


### PR DESCRIPTION
Pins awesome 4.3 to a pre-regression nixpkgs revision so the rest of nixpkgs can advance independently, then advances main nixpkgs by ~2.5 weeks.

## Why

`nix flake update` on 2026-05-24 broke awesome at both build *and* runtime — the lgi/cairo bump that landed via staging-next on 2026-05-08 changed an FFI signature that awesome 4.3's lua libs predate. Crashes in `lgi/override/cairo.lua:45` (`bad argument #1 to 'fromarray' (lgi.record expected, got table)`). Hits during build (example/doc generation runs `require('lgi')`) and again at runtime (every awesome lua lib does the same). Tracked upstream at https://github.com/NixOS/nixpkgs/issues/523345.

A previous attempt (#37, closed) tried to silence the build-time check (`AWESOME_IGNORE_LGI=1` + `-DGENERATE_DOC=OFF` + a postPatch). That made the build succeed but did nothing for the runtime crash, since the underlying lgi+cairo regression is still present. Lesson noted.

## Approach

Pin via a second nixpkgs flake input (`nixpkgs-awesome`) at commit `549bd84d` (2026-05-05), the latest pre-regression nixos-unstable. Add a tiny overlay that swaps `pkgs.awesome` for the pinned one. When upstream lands a fix, drop the input + overlay.

This isolates awesome's runtime closure (lua/lgi/cairo/glib) from the main `nixpkgs` advance. Main `nixpkgs` updates in commit 2.

## Changes

- **Commit 1** (`9c1873d`): add `nixpkgs-awesome` input + overlay in `flake.nix`. Drop-in replacement when upstream is fixed.
- **Commit 2** (`6c98aa4`): `nix flake update nixpkgs` — advances main nixpkgs from 2026-05-05 to 2026-05-23, bringing in claude-code 2.1.123 → 2.1.148, codex 0.128.0 → 0.133.0, kernel 6.18.26 → 6.18.32, brave, signal, docker, pipewire, glib 2.86 → 2.88, etc.

## Closure cost

`+84 paths, +190 MiB`. Expected — awesome's pinned runtime closure (cairo/glib/lua/xcb/etc. at May 5) lives alongside the rest of the system's May 23 versions. Most packages now show `x3` instead of `x2` in `nvd diff`; a few (glib, harfbuzz, pango, wayland) actually differ in version between the two closures. Process boundaries keep them separate — apps you launch from awesome use the May 23 closure, awesome itself uses its May 5 closure, no ABI mixing.

## Test plan

- [x] `nix build .#nixosConfigurations.thinkpad.pkgs.awesome` → clean build, store path `kw8j8mm3kn9pzf4...`.
- [x] Direct lgi check: `lua -e "local lgi=require('lgi'); print(lgi.cairo, lgi.Pango)"` from the wrapped luaEnv loads cleanly. (This is the *exact* code path that crashed at build/runtime before.)
- [x] Pin-only switch (commit 1): `sudo nixos-rebuild switch --flake .#thinkpad`, log out, log back in — awesome session works.
- [x] Pin + nixpkgs-update switch (commit 2): same flow, log out, log back in — awesome session still works.
- [x] `nvd diff /run/current-system result` shows awesome at the same store path before/after the update — pin is doing its job.

## Reverting later

When the upstream regression is fixed in nixos-unstable, drop the `nixpkgs-awesome` input from `flake.nix` and the overlay from `outputs`, then `nix flake update`.
