### PR TITLE
thinkpad: suspend-then-hibernate with swapfile-backed hibernation

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "dotfiles": {
       "locked": {
-        "lastModified": 1782766458,
-        "narHash": "sha256-/jz2LjgK/2mcsOpRzHeTx1Ic9vlCshDaeGrQpocf3jc=",
+        "lastModified": 1783366272,
+        "narHash": "sha256-QE8Igb/uKPdNdIZJ/9yYqdjEuac2/YPQELm4qPiS5bY=",
         "owner": "cwage",
         "repo": "dotfiles",
-        "rev": "01d24a21572707ab02edae1df242bf2b24f84434",
+        "rev": "2dd298aa76e5f65c945b12d76d939f489565f9ad",
         "type": "github"
       },
       "original": {
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782936463,
-        "narHash": "sha256-uFboRoG7fBgdP592N1wcNSA87ohssab6m+VuRxEUnIY=",
+        "lastModified": 1783358420,
+        "narHash": "sha256-UEyBpf+XmQe8laXfDzIlo11Er7E0rKrLS8jeMnMj0Ds=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "74b38179ac0820af3ea4a240ff12668fb2b8c72e",
+        "rev": "0d33882bd46c1f9ef62276700f5e5f2bd6ff6604",
         "type": "github"
       },
       "original": {
@@ -42,11 +42,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782636943,
-        "narHash": "sha256-ripjZa7BBLwL1uS5VJF3s/VpZpWt5ZIQEvkJ/FJNpQw=",
+        "lastModified": 1783233851,
+        "narHash": "sha256-jzisD+3wWZPC4QvAsKtYguiGsmlH2SN3Mjx5LWd68Ok=",
         "owner": "nix-community",
         "repo": "nix-index-database",
-        "rev": "058b1f9381fa79fcda49982370a750ff92dbba43",
+        "rev": "fab14c7b63499d57cb6673d5690168c3ec42b99a",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1782723713,
-        "narHash": "sha256-oPXCU/SSUokcGaJREHibG1CBX3+s/W7orDWQOZDsEeQ=",
+        "lastModified": 1783224372,
+        "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5aa0fbd538984f6e3d201be0005b4463d8b09f8",
+        "rev": "d407951447dcd00442e97087bf374aad70c04cea",
         "type": "github"
       },
       "original": {

--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -22,6 +22,22 @@
   # WireGuard tunnel address (host-specific; peer config lives in hosts/common).
   networking.wg-quick.interfaces.wg0.address = [ "10.10.16.4/32" ];
 
+  # Hibernation support: swapfile sized to RAM (31 GiB) so suspend-then-hibernate
+  # has somewhere to write the memory image. NixOS creates the file on activation.
+  swapDevices = [ { device = "/swapfile"; size = 32 * 1024; } ];
+
+  # Resume from the swapfile on the root partition. resume_offset is the
+  # swapfile's physical extent start, found after the file exists via:
+  #   sudo filefrag -v /swapfile | awk '$1=="0:" {print substr($4, 1, length($4)-2)}'
+  boot.resumeDevice = "/dev/disk/by-uuid/6dec2fdc-865e-4f53-b2e6-10a90509fb9d";
+  boot.kernelParams = [ "resume_offset=10444800" ];
+
+  # Lid close: suspend, then hibernate once systemd estimates the battery is
+  # near depletion (systemd >= 253 battery-discharge estimation; no fixed
+  # HibernateDelaySec so the adaptive logic applies). Overrides the plain
+  # "suspend" default in hosts/common.
+  services.logind.settings.Login.HandleLidSwitch = lib.mkForce "suspend-then-hibernate";
+
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions
   # on your system were taken.

--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -22,13 +22,14 @@
   # WireGuard tunnel address (host-specific; peer config lives in hosts/common).
   networking.wg-quick.interfaces.wg0.address = [ "10.10.16.4/32" ];
 
-  # Hibernation support: swapfile sized to RAM (31 GiB) so suspend-then-hibernate
-  # has somewhere to write the memory image. NixOS creates the file on activation.
+  # Hibernation support: 32 GiB swapfile (>= the 31 GiB of RAM) so
+  # suspend-then-hibernate has somewhere to write the memory image. NixOS
+  # creates the file on activation.
   swapDevices = [ { device = "/swapfile"; size = 32 * 1024; } ];
 
   # Resume from the swapfile on the root partition. resume_offset is the
   # swapfile's physical extent start, found after the file exists via:
-  #   sudo filefrag -v /swapfile | awk '$1=="0:" {print substr($4, 1, length($4)-2)}'
+  #   sudo filefrag -v /swapfile | awk '$1=="0:" {print $4+0}'
   boot.resumeDevice = "/dev/disk/by-uuid/6dec2fdc-865e-4f53-b2e6-10a90509fb9d";
   boot.kernelParams = [ "resume_offset=10444800" ];
 


### PR DESCRIPTION
Suspend used to be plain S3 forever, so leaving the lid closed for a few days drained the battery to a hard shutdown. Lid close now uses systemd's `suspend-then-hibernate`: normal suspend, then an RTC wake once systemd's battery-discharge estimation (systemd >= 253) projects the battery near 5%, at which point it hibernates to disk. Next power-on resumes the session from the hibernation image instead of coming up from a dead battery.

Changes
- Add a 32 GiB `/swapfile` (RAM-sized) on the thinkpad as the hibernation image target; NixOS creates it on activation.
- Set `boot.resumeDevice` to the root partition and `resume_offset=10444800` (the swapfile's physical extent start, from `filefrag -v /swapfile`).
- Override `HandleLidSwitch` from `suspend` (hosts/common default) to `suspend-then-hibernate` via `lib.mkForce`. `HibernateDelaySec` is left unset so the adaptive battery estimation applies rather than a fixed timer.
- Includes a routine `flake.lock` input bump (separate commit) that was already applied on the running system.

Test Plan
- `sudo nixos-rebuild switch --flake .#thinkpad` twice (swapfile creation, then resume_offset kernel param).
- Manual `sudo systemctl hibernate` round trip: machine wrote a ~12 GiB image, powered fully off, and resumed the session on power-on; verified in journalctl (`hibernation entry` -> S4 -> image restore -> `System returned from sleep operation 'hibernate'`).
- Lid-close suspend still works.
