### PR TITLE
Add encrypted vault support (gocryptfs, YubiKey tooling, sleep backstop)

### DIFF
--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -37,6 +37,10 @@ let
   ];
 in
 {
+  imports = [
+    ./vaults.nix
+  ];
+
   # Disable the legacy PC speaker / TTY beep.
   boot.blacklistedKernelModules = [ "pcspkr" "snd_pcsp" ];
 

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -179,7 +179,7 @@ in
     brightnessctl                  # backlight control
     polkit_gnome                   # policykit auth agent
     udiskie                        # automount
-    arandr                         # xrandr GUI
+    # arandr                       # xrandr GUI — broken upstream in current nixpkgs, rarely used
     scrot                          # screenshots
     xclip                          # clipboard
 

--- a/hosts/common/vaults.nix
+++ b/hosts/common/vaults.nix
@@ -44,6 +44,10 @@
     before = [ "sleep.target" ];
     unitConfig.ConditionPathExists = "/home/cwage/bin/vault";
     path = [ "/run/wrappers" pkgs.gocryptfs pkgs.procps pkgs.psmisc pkgs.coreutils ];
+    # systemd >= 255 no longer sets $HOME for User= services unless
+    # SetLoginEnvironment is on; the vault script locates everything under
+    # $HOME, so without this it silently finds no vaults and no-ops.
+    environment.HOME = "/home/cwage";
     serviceConfig = {
       Type = "oneshot";
       User = "cwage";

--- a/hosts/common/vaults.nix
+++ b/hosts/common/vaults.nix
@@ -1,0 +1,53 @@
+# Encrypted-at-rest working folders (gocryptfs "vaults", managed by the
+# `vault` helper in cwage/bin; design notes in cwage/safe PLAN.md).
+#
+# A vault is a gocryptfs ciphertext dir (~/vaults/NAME.enc) mounted to a
+# plaintext view (~/NAME) while in use. The master password is stored
+# age-encrypted to YubiKey (PIV) identities, so opening is plug-in-and-touch.
+# Lock policy is aggressive: the lock wrapper (~/bin/xscreensaver-lock)
+# force-closes all vaults on manual/idle/suspend locks; the systemd unit
+# below backstops suspend/hibernate so a hung X session or dead xss-lock
+# can't carry a mounted vault into sleep.
+
+{ pkgs, ... }:
+
+{
+  environment.systemPackages = with pkgs; [
+    gocryptfs
+    age
+    age-plugin-yubikey
+    yubikey-manager            # ykman, for PIV slot inspection/management
+  ];
+
+  # age-plugin-yubikey talks to the YubiKey PIV applet over PC/SC. Note:
+  # gpg's scdaemon can contend with pcscd for the reader; the lock wrapper
+  # already kills scdaemon on every lock, which keeps this from festering.
+  services.pcscd.enable = true;
+
+  # Directory scaffolding for the vault layout (the contents — ciphertext,
+  # wrapped passwords, age identity stubs — are mutable user data and are
+  # provisioned manually; see the `vault` script header). 0700: the wrapped
+  # password and identity stubs are nobody else's business.
+  systemd.tmpfiles.rules = [
+    "d /home/cwage/vaults 0700 cwage users -"
+    "d /home/cwage/.config/age 0700 cwage users -"
+  ];
+
+  # Force-close vaults before any sleep state (suspend, hibernate,
+  # suspend-then-hibernate all pull in sleep.target). Runs as cwage since
+  # the mounts are user FUSE mounts; /run/wrappers provides the setuid
+  # fusermount. User units can't order against the system sleep.target,
+  # which is why this is a system unit.
+  systemd.services.lock-vaults = {
+    description = "Force-close gocryptfs vaults before sleep";
+    wantedBy = [ "sleep.target" ];
+    before = [ "sleep.target" ];
+    unitConfig.ConditionPathExists = "/home/cwage/bin/vault";
+    path = [ "/run/wrappers" pkgs.gocryptfs pkgs.procps pkgs.psmisc pkgs.coreutils ];
+    serviceConfig = {
+      Type = "oneshot";
+      User = "cwage";
+      ExecStart = "/home/cwage/bin/vault close --all --force";
+    };
+  };
+}


### PR DESCRIPTION
Add tooling and a suspend backstop for encrypted-at-rest vaults (gocryptfs), plus an unrelated one-line fix disabling arandr (broken upstream).

Changes
- New `hosts/common/vaults.nix`:
  - Packages: `gocryptfs`, `age`, `age-plugin-yubikey`, `yubikey-manager`
  - `services.pcscd.enable` for YubiKey PIV access (note in-module about scdaemon contention; the lock wrapper kills scdaemon on every lock)
  - `systemd.tmpfiles.rules` scaffolding for `~/vaults` and `~/.config/age` (0700)
  - `lock-vaults` system unit, `Before=sleep.target` / `WantedBy=sleep.target`, running `/home/cwage/bin/vault close --all --force` as cwage — backstop so a hung X session or dead xss-lock can't carry a mounted vault into suspend/hibernate. System unit because user units can't order against the system `sleep.target`.
- `hosts/common/default.nix`: import the new module
- Separate commit: comment out `arandr` (build broken in the pinned nixos-unstable; rarely used)

Companion PRs: cwage/bin (the `vault` helper itself) and cwage/dotfiles (xss-lock integration). Design notes in cwage/safe `PLAN.md`.

Known gap (tracked in PLAN.md, out of scope here): the thinkpad's unencrypted `/swapfile` can retain plaintext pages that swapped out while a vault was open; real fix is encrypted swap.

Test Plan
- `nixos-rebuild switch --flake .#thinkpad` builds and activates
- `vault open` + lid close: `systemctl status lock-vaults` shows the unit fired at suspend; vault closed on resume
