### PR TITLE
thinkpad: fix suspend-then-hibernate never reaching hibernate

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -22,11 +22,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784588016,
-        "narHash": "sha256-ouZe80aWEhMLVMkqICFDN+JUw+0FJtCr/bh+hHtRtMg=",
+        "lastModified": 1784913159,
+        "narHash": "sha256-JWq0BfjO4ktpH5USfQNQzdvHpIDT8fSKD5K7LvdMRFs=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "deeb6b7eb7e0c44ae1819c051ce175bd92a85100",
+        "rev": "079a3b5d1aa6a719920a51316253b7d6dd22738d",
         "type": "github"
       },
       "original": {
@@ -60,11 +60,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1784310968,
-        "narHash": "sha256-rkSPTePrKqs4dg+i7ZFCq93+HrClac6oSwXX927SVjA=",
+        "lastModified": 1784723954,
+        "narHash": "sha256-1CfD8ZUjCkTgjsneLZ/lxCHhgDfqxxE7/GX0MmsgiqA=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "779c32a00155994c86cde8213a8dd4df139d4355",
+        "rev": "a017f5b72210026af5b3ac5949f08d94380a6fbd",
         "type": "github"
       },
       "original": {
@@ -104,11 +104,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1784497964,
-        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "lastModified": 1784796856,
+        "narHash": "sha256-wWFrV5/Qbm+lyt5x20E/bSbfJiGKMo4RCxZV8cl/WZI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "rev": "e2587caef70cea85dd97d7daab492899902dbf5d",
         "type": "github"
       },
       "original": {

--- a/hosts/common/default.nix
+++ b/hosts/common/default.nix
@@ -220,7 +220,12 @@ in
     firejail                         # profile-based sandbox wrapper
     nsjail                           # namespaces + seccomp + cgroups in one tool
     podman-compose                   # rootless container compose (podman enabled below)
-    mitmproxy                        # HTTPS proxy for allowlisting outbound API traffic
+    # mitmproxy - HTTPS proxy for allowlisting outbound API traffic.
+    # Temporarily disabled: broken upstream in current nixpkgs. mitmproxy
+    # 12.2.3 pins msgpack<=1.1.2 but nixpkgs ships msgpack 1.2.1, so the
+    # pythonRuntimeDepsCheck hook fails the build. Re-enable once nixpkgs
+    # bumps mitmproxy (or relaxes the msgpack bound).
+    # mitmproxy
     strace                           # syscall tracer (useful for building seccomp profiles)
     libseccomp                       # seccomp library + scmp_sys_resolver CLI
     rubyPackages.seccomp-tools       # seccomp BPF dumping/analysis (david942j)

--- a/hosts/thinkpad/configuration.nix
+++ b/hosts/thinkpad/configuration.nix
@@ -33,11 +33,20 @@
   boot.resumeDevice = "/dev/disk/by-uuid/6dec2fdc-865e-4f53-b2e6-10a90509fb9d";
   boot.kernelParams = [ "resume_offset=10444800" ];
 
-  # Lid close: suspend, then hibernate once systemd estimates the battery is
-  # near depletion (systemd >= 253 battery-discharge estimation; no fixed
-  # HibernateDelaySec so the adaptive logic applies). Overrides the plain
-  # "suspend" default in hosts/common.
+  # Lid close: suspend, then hibernate to the swapfile after a fixed delay in
+  # S3. Overrides the plain "suspend" default in hosts/common.
   services.logind.settings.Login.HandleLidSwitch = lib.mkForce "suspend-then-hibernate";
+
+  # Use an explicit HibernateDelaySec instead of systemd's battery-discharge
+  # estimation. The estimation path was never arming the RTC wake alarm that
+  # triggers the hibernate step, so the machine sat in S3 (deep suspend, which
+  # still drains ~1-2%/hr) until the battery hard-died in the bag. A fixed
+  # delay arms a definite RTC alarm; this hardware wakes from the RTC in S3
+  # (verified with `rtcwake -m mem`), so the hibernate step now fires. 30min is
+  # short enough to preserve battery in a bag but long enough that a brief
+  # lid-close-and-reopen just resumes from S3 rather than doing a slow
+  # hibernate round trip. Tune upward if quick lid closes hibernate too eagerly.
+  systemd.sleep.settings.Sleep.HibernateDelaySec = "30min";
 
   # This value determines the NixOS release from which the default
   # settings for stateful data, like file locations and database versions


### PR DESCRIPTION
Fixes the ThinkPad dying completely while "hibernating" in the bag, plus an unrelated build unblock and a flake bump.

## Hibernation fix (the main change)

The lid-close action was already `suspend-then-hibernate`, and the machine suspended fine — but it **never escalated from S3 to hibernate**. Across the whole journal history: 69 S3 suspends, 0 automatic hibernations. One incident sat in S3 for 51 hours straight before a manual wake. So it just drained in deep suspend (~1-2%/hr) until the battery hard-died.

Root cause: with an empty `sleep.conf`, systemd relied on its battery-discharge *estimation* to decide when to wake and hibernate, and that path never armed the RTC wake alarm that triggers the hibernate step.

Fix: set an explicit `HibernateDelaySec = "30min"` (`systemd.sleep.settings.Sleep`), so systemd arms a definite RTC alarm instead of the estimation that wasn't firing.

Verified:
- Hardware wakes from the RTC in S3 (`sudo rtcwake -m mem -s 120` — woke itself after 120s).
- End-to-end escalation, tested with a temporary 2min delay:
  ```
  Performing sleep operation 'suspend'...
  Performing sleep operation 'hibernate'...   # ~2 min later
  PM: hibernation: hibernation entry
  PM: hibernation: hibernation exit           # resumed session from disk
  ```

`30min` is the tunable knob: shorter drains less in the bag, longer avoids hibernating on brief lid-closes.

## Disable mitmproxy (unrelated, build unblock)

mitmproxy 12.2.3 pins `msgpack<=1.1.2` but current nixpkgs ships `msgpack 1.2.1`, so `pythonRuntimeDepsCheck` fails the build. Commented out (with a note) until nixpkgs bumps mitmproxy or relaxes the bound. This is part of the agent-sandboxing tooling — the HTTPS-allowlisting proxy — so that piece is inactive until re-enabled.

## flake.lock

Routine input bump (nixpkgs / home-manager / nixos-hardware).

## Test plan
- `sudo nixos-rebuild switch --flake .#thinkpad` succeeds.
- `cat /etc/systemd/sleep.conf` shows `HibernateDelaySec=30min`.
- Hibernation escalation confirmed via the journal chain above.
